### PR TITLE
Introduce variables for the page ids

### DIFF
--- a/Configuration/TypoScript/010_Libs/Menu.t3s
+++ b/Configuration/TypoScript/010_Libs/Menu.t3s
@@ -2,8 +2,8 @@ lib.menu = HMENU
 
 lib.menu {
     special = directory
-    special.value = 12
-    excludeUidList = 48,50,52,53,60,63,64
+    special.value = {$ids.home}
+    excludeUidList = {$ids.menuExcluded}
 
     1 = TMENU
     1.wrap = <ul class="mainmenu">|</ul>

--- a/Configuration/TypoScript/030_Page/Page.t3s
+++ b/Configuration/TypoScript/030_Page/Page.t3s
@@ -40,5 +40,7 @@ page.10 {
     variables {
         headline = TEXT
         headline.field = subtitle // title
+        IDS_HOME = TEXT
+        IDS_HOME.value = {$ids.home}
     }
 }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,14 +1,8 @@
 ### Dependencies ###
 <INCLUDE_TYPOSCRIPT: source="FILE:EXT:fluid_styled_content/Configuration/TypoScript/Static/constants.txt">
 
-#################
-### Variables ###
-#################
-
 ### Directories ###
-
 resDir = EXT:tmpl_ssgaac/Resources
 
 
 styles.content.links.allowTags := addToList(abbr, acronym)
-

--- a/Resources/Private/Layouts/DefaultLayout.html
+++ b/Resources/Private/Layouts/DefaultLayout.html
@@ -3,7 +3,7 @@
 		<f:translate key="LLL:EXT:tmpl_ssgaac/Resources/Private/Language/locallang.xlf:Jump to main content"/>
 	</a>
 
-	<f:render partial="Head"/>
+	<f:render partial="Head" arguments="{_all}"/>
 	<div class="clear"></div>
 
 	<f:render partial="Menu"/>

--- a/Resources/Private/Partials/Head.html
+++ b/Resources/Private/Partials/Head.html
@@ -1,5 +1,5 @@
 <div id="head" class="grid_16">
-    <a href="./">
+    <f:link.page pageUid="{IDS_HOME}">
         <h1><f:translate key="LLL:EXT:tmpl_ssgaac/Resources/Private/Language/locallang.xlf:Specialised Information Service Anglo-American Culture" /></h1>
-    </a>
+    </f:link.page>
 </div>


### PR DESCRIPTION
Page ids variables for the logo link and for the menu are
assigned in the TYPO3 Backend.
Add ids.home and ids.menuExcluded to your constants.

Related to: AAC-143